### PR TITLE
Add container mulled-v2-7bde9f0045905cc44cb726ad016ff10c70a194d7:52cb2af3aa456a0406def85607967e5ba44542f9.

### DIFF
--- a/combinations/mulled-v2-7bde9f0045905cc44cb726ad016ff10c70a194d7:52cb2af3aa456a0406def85607967e5ba44542f9-0.tsv
+++ b/combinations/mulled-v2-7bde9f0045905cc44cb726ad016ff10c70a194d7:52cb2af3aa456a0406def85607967e5ba44542f9-0.tsv
@@ -1,0 +1,1 @@
+parallel=20160622,gawk=4.1.3,samtools=0.1.19,freebayes=1.1.0


### PR DESCRIPTION
Hash: mulled-v2-7bde9f0045905cc44cb726ad016ff10c70a194d7:52cb2af3aa456a0406def85607967e5ba44542f9
Packages:
- parallel=20160622
- gawk=4.1.3
- samtools=0.1.19
- freebayes=1.1.0
For:
- freebayes.xml
Generated with Planemo.